### PR TITLE
prevent failures when no clones found

### DIFF
--- a/DuplicateCodeDetector/CloneGroups.cs
+++ b/DuplicateCodeDetector/CloneGroups.cs
@@ -36,19 +36,26 @@ namespace NearCloneDetector
 
             var duplicationFactors = CloneSets.Select(c => c.Count).ToList();
 
-            Console.WriteLine($"Avg Duplication Factor: {duplicationFactors.Average()}");
-            duplicationFactors.Sort();
-            double median;
-            int midpoint = duplicationFactors.Count / 2;
-            if (duplicationFactors.Count % 2 == 0)
+            if (duplicationFactors.Count > 0)
             {
-                median = (duplicationFactors[midpoint] + duplicationFactors[midpoint + 1]) / 2;
+                Console.WriteLine($"Avg Duplication Factor: {duplicationFactors.Average()}");
+                duplicationFactors.Sort();
+                double median;
+                int midpoint = duplicationFactors.Count / 2;
+                if (duplicationFactors.Count % 2 == 0)
+                {
+                    median = (duplicationFactors[midpoint] + duplicationFactors[midpoint + 1]) / 2;
+                }
+                else
+                {
+                    median = duplicationFactors[midpoint];
+                }
+                Console.WriteLine($"Median Duplication Factor: {median}");
             }
             else
             {
-                median = duplicationFactors[midpoint];
+                Console.WriteLine("No duplicates found.");
             }
-            Console.WriteLine($"Median Duplication Factor: {median}");
         }
 
         private int MakeCloneSetTransitive()


### PR DESCRIPTION
Skip printing of average duplication factor when it cannot be calculated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/near-duplicate-code-detector/1)
<!-- Reviewable:end -->
