### PR TITLE
Add an F# tokenizer

### DIFF
--- a/tokenizers/FSharpTokenizer/FSharpTokenizer.sln
+++ b/tokenizers/FSharpTokenizer/FSharpTokenizer.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpTokenizer", "FSharpTokenizer\FSharpTokenizer.fsproj", "{F658D8FD-352D-4112-A3E8-A1EE26DC7540}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Debug|x64.Build.0 = Debug|Any CPU
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Debug|x86.Build.0 = Debug|Any CPU
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Release|x64.ActiveCfg = Release|Any CPU
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Release|x64.Build.0 = Release|Any CPU
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Release|x86.ActiveCfg = Release|Any CPU
+		{F658D8FD-352D-4112-A3E8-A1EE26DC7540}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tokenizers/FSharpTokenizer/FSharpTokenizer/FSharpTokenizer.fsproj
+++ b/tokenizers/FSharpTokenizer/FSharpTokenizer/FSharpTokenizer.fsproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <Tailcalls>true</Tailcalls>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Compiler.Service" Version="35.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
+  </ItemGroup>
+</Project>

--- a/tokenizers/FSharpTokenizer/FSharpTokenizer/Program.fs
+++ b/tokenizers/FSharpTokenizer/FSharpTokenizer/Program.fs
@@ -1,0 +1,76 @@
+﻿module FSharpTokenizer
+
+open System
+open System.IO
+open System.IO.Compression
+open System.Linq
+
+open FSharp.Compiler.SourceCodeServices
+
+open Newtonsoft.Json
+
+let rec tokenizeLine (tokenizer : FSharpLineTokenizer) state (line : string) (tokens : _ list) =
+    match tokenizer.ScanToken(state) with
+    | Some tok, state ->
+        let value = line.Substring(tok.LeftColumn, tok.RightColumn - tok.LeftColumn + 1)
+        tokenizeLine tokenizer state line ({| Token = tok; Value = value |}::tokens)
+    | None, state -> state, tokens
+
+let rec tokenizeLines (sourceTok : FSharpSourceTokenizer) state count tokens lines =
+    match lines with
+    | line::lines ->
+        let tokenizer = sourceTok.CreateLineTokenizer(line)
+        let state, tokens = tokenizeLine tokenizer state line tokens
+        tokenizeLines sourceTok state (count + 1) tokens lines
+    | [] -> List.rev tokens
+
+let tokenizeFile (filePath : string) =
+    [
+        use rawSource = new StreamReader(filePath)
+
+        let mutable line = rawSource.ReadLine()
+        while not (isNull line) do
+            yield line
+            line <- rawSource.ReadLine()
+    ]
+    |> tokenizeLines (FSharpSourceTokenizer([], Some filePath)) FSharpTokenizerLexState.Initial 1 []
+
+let getFileIdentifierTokens (filepath : string) (onlyIdentifiers : bool) =
+    let tokens = tokenizeFile filepath
+    if onlyIdentifiers then
+        tokens
+        |> List.filter (fun t -> t.Token.CharClass = FSharpTokenCharKind.Identifier)
+    else
+        tokens
+    |> List.map (fun t -> t.Value)
+
+let getJsonForFile (filepath : string) (onlyIdentifiers : bool) (baseDir : string) : string =
+    {|
+        tokens   = getFileIdentifierTokens filepath onlyIdentifiers
+        filename = Path.GetRelativePath(baseDir, filepath)
+    |}
+    |> JsonConvert.SerializeObject
+
+let extractForProjectFolder (baseDir : string) (outputDir : string) (onlyIdentifiers : bool) (projectDir : string) =
+
+    let projectDirName = Path.GetFileName(projectDir)
+
+    use fileStream = File.Create(Path.Combine(outputDir, projectDirName + ".jsonl.gz"))
+    use gzipStream = new GZipStream(fileStream, CompressionMode.Compress, false)
+    use textStream = new StreamWriter(gzipStream)
+
+    let allFiles = Directory.EnumerateFiles(projectDir, "*.fs", SearchOption.AllDirectories)
+
+    for fileJson in allFiles.AsParallel().Select(fun f -> getJsonForFile f onlyIdentifiers baseDir) do
+        textStream.WriteLine(fileJson)
+
+[<EntryPoint>]
+let main argv =
+    if argv.Length <> 3 then
+        Console.WriteLine("Usage <projectsFolder> <outputFolder> true|false");
+        -1
+    else
+        Directory.EnumerateDirectories(argv.[0]).AsParallel()
+        |> Seq.iter (extractForProjectFolder argv.[0] argv.[1] (Boolean.Parse(argv.[2])))
+
+        0


### PR DESCRIPTION
This PR adds an F# tokenizer.

It's basically a port of the C# one to F#, with the C# Roslyn code replaced with the F# Compiler Service.